### PR TITLE
Do not apply mask in case of empty input

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -18,8 +18,12 @@ export class InputService {
 
     applyMask(isNumber: boolean, rawValue: string): string {
         let {allowNegative, precision, thousands, decimal} = this.options;
-        rawValue = isNumber ? new Number(rawValue).toFixed(precision) : rawValue;  
+        rawValue = isNumber ? new Number(rawValue).toFixed(precision) : rawValue;
         let onlyNumbers = rawValue.replace(/[^0-9]/g, "");
+
+        // Do not apply any mask in case of empty input
+        if (!onlyNumbers) return "";
+
         let integerPart = onlyNumbers.slice(0, onlyNumbers.length - precision).replace(/^0*/g, "").replace(/\B(?=(\d{3})+(?!\d))/g, thousands);
 
         if (integerPart == "") {
@@ -48,13 +52,13 @@ export class InputService {
         if (this.options.decimal) {
             value = value.replace(this.options.decimal, ".");
         }
-        
+
         return parseFloat(value);
     }
 
     changeToNegative(): void {
         if (this.options.allowNegative && this.rawValue != "" && this.rawValue.charAt(0) != "-" && this.value != 0) {
-            this.rawValue = "-" + this.rawValue; 
+            this.rawValue = "-" + this.rawValue;
         }
     }
 


### PR DESCRIPTION
Problem: In case of input model contains null or empty value directive still shows "$ 0." mask at the input UI.

After this fix directive will check if input model contains null or empty value then input will show nothing at UI. In case of model value is 0 - then mask will be applied like "$ 0.00" or so, depends on settings. 

