### PR TITLE
Fix type 'KeyValueDiffer' is not ge neric.

### DIFF
--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -18,7 +18,7 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
     @Input() options: any = {};
 
     inputHandler: InputHandler;
-    keyValueDiffer: KeyValueDiffer<any, any>;
+    keyValueDiffer: KeyValueDiffer;
 
     optionsTemplate = {
         align: "right",


### PR DESCRIPTION
When I updated my packages to new angular version 4.x, I started got these error.

Type 'KeyValueDiffer' is not generic.

So I fix it in my environment and make several tests and looks like everything is ok.

Let me know what do you think about this solution.