### PR TITLE
[Feature] Added support to injectable options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './src/currency-mask.directive';
 export * from './src/currency-mask.module';
+export * from './src/currency-mask-config';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,141 @@
+{
+  "name": "ng2-currency-mask",
+  "version": "4.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@angular/common": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.0.0.tgz",
+      "integrity": "sha1-yhiYMiL9q07Kp6i5ntpv9mHm3JI=",
+      "dev": true
+    },
+    "@angular/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha1-4aoGGm+O8mn5dIrxp7wpD5037Ww=",
+      "dev": true
+    },
+    "@angular/compiler-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.0.0.tgz",
+      "integrity": "sha1-NbLUDNNRNa7OxL5llTIUj1rGfaY=",
+      "dev": true,
+      "requires": {
+        "@angular/tsc-wrapped": "4.0.0",
+        "minimist": "1.2.0",
+        "reflect-metadata": "0.1.10"
+      }
+    },
+    "@angular/core": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.0.0.tgz",
+      "integrity": "sha1-/Yd+B0sp36nGO5aiGZX8dVbUI6M=",
+      "dev": true
+    },
+    "@angular/forms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.0.0.tgz",
+      "integrity": "sha1-AxYwR6LoSvQhBicNouH0erD6/Dc=",
+      "dev": true
+    },
+    "@angular/platform-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.0.0.tgz",
+      "integrity": "sha1-USrpqxnMwl+nkCf0TikbzuI2zSs=",
+      "dev": true
+    },
+    "@angular/tsc-wrapped": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.0.0.tgz",
+      "integrity": "sha1-6pHu2pgCnNsKSsN9XiXZ0SpDM8E=",
+      "dev": true,
+      "requires": {
+        "tsickle": "0.21.6"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "reflect-metadata": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz",
+      "integrity": "sha1-tPg3BEFqytiZiMmxVjXUfgO5NEo=",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.1.tgz",
+      "integrity": "sha1-Omm9+fDKCphjAzcNRwj3K9+sg1Y=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+      "dev": true
+    },
+    "tsickle": {
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
+      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.5.6",
+        "source-map-support": "0.4.15"
+      }
+    },
+    "typescript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
+      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
+      "dev": true
+    },
+    "zone.js": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.5.tgz",
+      "integrity": "sha1-eQbgF0gsv/TD8HnFw0MFzpQfW6I=",
+      "dev": true
+    }
+  }
+}

--- a/src/currency-mask-config.ts
+++ b/src/currency-mask-config.ts
@@ -1,0 +1,19 @@
+import { OpaqueToken, ClassProvider } from '@angular/core';
+
+export class CurrencyMaskConfig {
+    align: string = 'right';
+    allowNegative: boolean = true;
+    decimal: string = '.';
+    precision: number = 2;
+    prefix: string = '$ ';
+    suffix: string = '';
+    thousands: string = ',';
+    allowZero: boolean = true;
+}
+
+export const CURRENCY_MASK_CONFIG_TOKEN = new OpaqueToken('CurrencyMaskConfig')
+
+export const CURRENCY_MASK_CONFIG_PROVIDER: ClassProvider = {
+    provide: CURRENCY_MASK_CONFIG_TOKEN,
+    useClass: CurrencyMaskConfig
+}

--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -1,4 +1,10 @@
-import { AfterViewInit, Directive, DoCheck, ElementRef, forwardRef, HostListener, KeyValueDiffer, KeyValueDiffers, Input, OnInit } from "@angular/core";
+import { CurrencyMaskConfig, CURRENCY_MASK_CONFIG_TOKEN } from './currency-mask-config';
+import {
+    AfterViewInit, Directive, DoCheck,
+    ElementRef, forwardRef, HostListener, KeyValueDiffer,
+    KeyValueDiffers, Input, OnInit, Inject,
+    Optional
+} from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
 import { InputHandler } from "./input.handler";
@@ -31,8 +37,14 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
         thousands: ","
     };
 
-    constructor(private elementRef: ElementRef, private keyValueDiffers: KeyValueDiffers) {
+    constructor(
+        private elementRef: ElementRef,
+        private keyValueDiffers: KeyValueDiffers,
+        @Optional() @Inject(CURRENCY_MASK_CONFIG_TOKEN) private currencyMaskConfig: CurrencyMaskConfig) {
         this.keyValueDiffer = keyValueDiffers.find({}).create(null);
+
+        //  use currencyMaskConfig if is not null, else use the internal config (optionsTemplate)
+        this.optionsTemplate = this.currencyMaskConfig || this.optionsTemplate;
     }
 
     ngAfterViewInit() {

--- a/src/currency-mask.module.ts
+++ b/src/currency-mask.module.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import { NgModule } from "@angular/core";
-
+import { NgModule, ModuleWithProviders } from "@angular/core";
 import { CurrencyMaskDirective } from "./currency-mask.directive";
+import { CURRENCY_MASK_CONFIG_PROVIDER } from "./currency-mask-config";
 
 @NgModule({
     imports: [
@@ -17,4 +17,12 @@ import { CurrencyMaskDirective } from "./currency-mask.directive";
     ]
 })
 export class CurrencyMaskModule {
+    static forRoot(): ModuleWithProviders {
+        return {
+            ngModule: CurrencyMaskModule,
+            providers: [
+                CURRENCY_MASK_CONFIG_PROVIDER
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Hello! 

This PR brings support to define injectable options for all application. 
I think the issue [#42](https://github.com/cesarrew/ng2-currency-mask/issues/42) can be closed.

To use it would be that way: 
```ts
import { CURRENCY_MASK_CONFIG_TOKEN, CurrencyMaskConfig, CurrencyMaskModule } from 'ng2-currency-mask';

export class CustomCurrencyMaskConfig extends CurrencyMaskConfig {
  prefix = '<myCustomPrefix>'
}

@NgModule({
    imports: [CurrencyMaskModule.forRoot()], // forRoot is to register the injectable options, it isn't required
   providers: [
      { provide: CURRENCY_MASK_CONFIG_TOKEN, useClass: CustomCurrencyMaskConfig }
   ]
 })
export class MyModule { }
```
I've tested the directive and everything is ok.

Thanks. 