### PR TITLE
Provide option to allow a negative sign to be entered before a number…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Available options:
 
  * `align` - Text alignment in input. (default: `right`)
  * `allowNegative` - If `true` can input negative values.  (default: `true`)
+ * `allowNegativeZero` - If `true` can input a negative sign before numbers are entered.  (default: `false`)
  * `decimal` -  Separator of decimals (default: `'.'`)
  * `precision` - Number of decimal places (default: `2`)
  * `prefix` - Money prefix (default: `'$ '`)

--- a/src/currency-mask.config.ts
+++ b/src/currency-mask.config.ts
@@ -4,6 +4,7 @@ export interface CurrencyMaskConfig {
 
     align: string;
     allowNegative: boolean;
+    allowNegativeZero: boolean;
     allowZero: boolean;
     decimal: string;
     precision: number;

--- a/src/currency-mask.directive.ts
+++ b/src/currency-mask.directive.ts
@@ -24,6 +24,7 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
     optionsTemplate = {
         align: "right",
         allowNegative: true,
+        allowNegativeZero: false,
         allowZero: true,
         decimal: ".",
         precision: 2,

--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -21,7 +21,7 @@ export class InputService {
     }
 
     applyMask(isNumber: boolean, rawValue: string): string {
-        let { allowNegative, decimal, precision, prefix, suffix, thousands } = this.options;
+        let { allowNegative, allowNegativeZero, decimal, precision, prefix, suffix, thousands } = this.options;
         rawValue = isNumber ? new Number(rawValue).toFixed(precision) : rawValue;
         let onlyNumbers = rawValue.replace(/[^0-9]/g, "");
 
@@ -43,7 +43,7 @@ export class InputService {
         }
 
         let isZero = parseInt(integerPart) == 0 && (parseInt(decimalPart) == 0 || decimalPart == "");
-        let operator = (rawValue.indexOf("-") > -1 && allowNegative && !isZero) ? "-" : "";
+        let operator = (rawValue.indexOf("-") > -1 && allowNegative && (!isZero || allowNegativeZero)) ? "-" : "";
         return operator + prefix + newRawValue + suffix;
     }
 
@@ -64,7 +64,9 @@ export class InputService {
     changeToNegative(): void {
         if (this.options.allowNegative && this.rawValue != "" && this.rawValue.charAt(0) != "-" && this.value != 0) {
             this.rawValue = "-" + this.rawValue;
-        }
+        } else if(this.options.allowNegativeZero && (this.rawValue == "" || this.value == 0)) {
+			this.rawValue = this.applyMask(false, "-0");
+		}
     }
 
     changeToPositive(): void {


### PR DESCRIPTION
Allow users to input a negative sign before numbers are entered.


For example:

![negativefirst](https://user-images.githubusercontent.com/2233700/28905228-3291d3e2-7842-11e7-9fa4-63c379fea298.gif)