### PR TITLE
Wrong value (model and mask) when editing an input

### DIFF
--- a/src/input.service.ts
+++ b/src/input.service.ts
@@ -39,6 +39,7 @@ export class InputService {
         let decimalPart = onlyNumbers.slice(onlyNumbers.length - precision);
 
         if (precision > 0) {
+            decimalPart = "0".repeat(precision - decimalPart.length) + decimalPart;
             newRawValue += decimal + decimalPart;
         }
 


### PR DESCRIPTION
When the input value are selected, if the user press some key not number (backspace, delete, space) and later hit a number, the value and mask are inputted correctly.

But, if the input value are selected and the user hit just one number, the model value and mask goes wrong. Ex:

Step 1 - Value inputted (and losses focus):
<img width="98" alt="0" src="https://user-images.githubusercontent.com/5577230/32407160-1547a6b8-c16c-11e7-9b63-86eb8f7f2899.png">

Step 2 - Focus the input, and select all value:
<img width="110" alt="2" src="https://user-images.githubusercontent.com/5577230/32407161-156b0e14-c16c-11e7-80a3-bbce0abed73d.png">

Step 3 - Hit some number key, in the example, I used number 1:
<img  width="114" alt="3" src="https://user-images.githubusercontent.com/5577230/32407162-158d781e-c16c-11e7-82aa-abf82875d7cb.png">

The correct masked value above need to be: R$ 0,01
The correct model value above need to be: 0.01
