### PR TITLE
Update input.handler.ts

### DIFF
--- a/projects/ng2-currency-mask/src/lib/input.handler.ts
+++ b/projects/ng2-currency-mask/src/lib/input.handler.ts
@@ -202,8 +202,10 @@ export class InputHandler {
     private setCursorPosition(event: any): void {
         let rawValueWithoutSuffixEndPosition = this.inputService.getRawValueWithoutSuffixEndPosition();
 
+        // For some reason in android the event got override before the timeout and change the target, so I needed to store the input target in a variable
+        const inputElement = event.target;
         setTimeout(function () {
-            event.target.setSelectionRange(rawValueWithoutSuffixEndPosition, rawValueWithoutSuffixEndPosition);
+            inputElement.setSelectionRange(rawValueWithoutSuffixEndPosition, rawValueWithoutSuffixEndPosition);
         }, 0);
     }
 }


### PR DESCRIPTION
For some reason in android the event got override before the timeout and change the target, so I needed to store the input target in a variable