### PR TITLE
Fix for autocomplete not updating modal

### DIFF
--- a/projects/ng2-currency-mask/src/lib/currency-mask.directive.ts
+++ b/projects/ng2-currency-mask/src/lib/currency-mask.directive.ts
@@ -106,7 +106,14 @@ export class CurrencyMaskDirective implements AfterViewInit, ControlValueAccesso
     @HostListener("paste", ["$event"])
     handlePaste(event: any) {
         if (!this.isChromeAndroid()) {
-            this.inputHandler.handlePaste(event);
+            this.inputHandler.handlePasteAndFocusOut(event);
+        }
+    }
+
+    @HostListener("focusout", ["$event"])
+    handleFocusout(event: any) {
+        if (!this.isChromeAndroid()) {
+            this.inputHandler.handlePasteAndFocusOut(event);
         }
     }
 

--- a/projects/ng2-currency-mask/src/lib/input.handler.ts
+++ b/projects/ng2-currency-mask/src/lib/input.handler.ts
@@ -139,16 +139,12 @@ export class InputHandler {
         this.inputService.fixCursorPosition();
     }
 
-    handlePaste(event: any): void {
+    handlePasteAndFocusOut(event: any): void {
         if (this.isReadOnly()) {
             return;
         }
-
-        setTimeout(() => {
-            this.inputService.updateFieldValue();
-            this.setValue(this.inputService.value);
-            this.onModelChange(this.inputService.value);
-        }, 1);
+        event.preventDefault();
+        this.onModelChange(this.inputService.value);
     }
 
     updateOptions(options: any): void {


### PR DESCRIPTION
Since detecting autocomplete is not trivial and chrome, firefox, etc
handle auto completion differently I made the decision to use the
focusout event to update the modal of the input.